### PR TITLE
FEATURE: Added seller country option to enhance VAT Number validation.

### DIFF
--- a/js/pmprovat.js
+++ b/js/pmprovat.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function(){
 	//find billing country
 	var billing_country = jQuery("select[name='bcountry']");
-	
+
 	//find gateway option
 	var gateway_option = jQuery("input[name='gateway']");
 	if(gateway_option.length < 0)
@@ -30,6 +30,11 @@ jQuery(document).ready(function(){
 			jQuery('#vat_number_validation_tr').hide();
 			if(jQuery('#eucountry').val() == '' && jQuery('select[name=bcountry]').val() != '')
 				jQuery('#eucountry').val( country );
+			
+			if(pmprovat.seller_country == country)
+				jQuery('#have_vat_number').hide();
+			else
+				jQuery('#have_vat_number').show();
 		}
 		else
 		{


### PR DESCRIPTION
According to EU regulations, if a buyer is in the same country as the seller, the buyer cannot bypass the VAT by using a VAT number. If the buyer and seller country are the same, we now remove the option to provide a VAT number.