### PR TITLE
BUG: Fixed incorrect CSS class when displaying verified text for VAT …

### DIFF
--- a/js/pmprovat.js
+++ b/js/pmprovat.js
@@ -84,7 +84,8 @@ jQuery(document).ready(function(){
 					if(response.success == true)
 					{						
 						//print message
-						jQuery('#pmpro_message, #vat_number_message').show();							
+						jQuery('#pmpro_message, #vat_number_message').show();
+						jQuery('#pmpro_message, #vat_number_message').removeClass('pmpro_error');
 						jQuery('#pmpro_message, #vat_number_message').addClass('pmpro_success');
 						jQuery('#pmpro_message, #vat_number_message').html(pmprovat.verified_text);
 


### PR DESCRIPTION
…number verification.

If the following procedure was followed:
1. Incorrect VAT number was entered and failed verification, error message displayed with red background.
2. Correct VAT number is now entered and verifies, error message still displays with red background.

This commit fixes the issue. Upon success the background is changed to green.