### PR TITLE
BUG FIX: Fatal error when exporting orders

### DIFF
--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -686,7 +686,7 @@ function pmprovat_vat_number_for_orders_csv($order) {
 }
 
 function pmprovat_eucountry_for_orders_csv($order) {
-	$vat_country = pmprovat_iso2vat(pmprovatpmpro_getMatches("/{EU_VAT_COUNTRY:([^}]*)}/", $order->notes, true));
+	$vat_country = pmprovat_iso2vat(pmpro_getMatches("/{EU_VAT_COUNTRY:([^}]*)}/", $order->notes, true));
 	return $vat_country;
 }
 


### PR DESCRIPTION
Would have been good to have tested the order export first...
Also, why wrap a simple `preg_match_all()` function call (which is fast) with a custom function that does the same (which is slow)? - i.e. `pmpro_getMatches()`. It has absolutely no additional value nor does it improve ease of use.