### PR TITLE
Add filter to skip vat verification (always true)

### DIFF
--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -197,7 +197,11 @@ function pmprovat_getVATValidation() {
  * Helper function to verify a VAT number.
  */
 function pmprovat_verify_vat_number($country, $vat_number)
-{		
+{
+	if( apply_filters('pmprovat_skip_validation', false) ){
+		return true;
+	}
+
 	$vatValidation = pmprovat_getVATValidation();
 		
 	if(empty($country) || empty($vat_number)) {


### PR DESCRIPTION
This is expecially useful in combination of what discusses in #18 .

Consider the Italy same-country case.
We must add vat if you are a company AND if you are a private. No differences.
The vat verification is a step that comes up later on, when invoice is maybe emitted.

Also, in Spain there are special cases where you never emit invoices for orders < 100€.

Last but not least: since I'm running an high traffic platform, I'm facing a lot of issues that does not permit users to checkout because of the SoapFail Exception which frequently happens as reported in #39 

That's why this filter is needed.