### PR TITLE
Added filter pmprovat_hide_vat_if_same_country

### DIFF
--- a/js/pmprovat.js
+++ b/js/pmprovat.js
@@ -33,7 +33,7 @@ jQuery(document).ready(function(){
 			if(jQuery('#eucountry').val() == '' && jQuery('select[name=bcountry]').val() != '')
 				jQuery('#eucountry').val( country );
 			
-			if(pmprovat.seller_country == country)
+			if(pmprovat.seller_country == country && pmprovat.hide_vat_same_country)
 				jQuery('#vat_have_number').hide();
 			else
 				jQuery('#vat_have_number').show();

--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -167,6 +167,7 @@ function pmprovat_enqueue_scripts() {
 				'seller_country' => get_option('pmprovt_seller_country'),
 				'verified_text' => __('VAT number was verifed', 'pmprovat'),
 				'not_verified_text' => __('VAT number was not verifed. Please try again.', 'pmprovat'),				
+				'hide_vat_same_country' => apply_filters( 'pmprovat_hide_vat_if_same_country', true ),
 			)
 		);
 		//enqueue


### PR DESCRIPTION
Previously, when a user's billing country was the same as the VAT selling country, they would not be given the option to enter a VAT number; however, there are country-specific rules around whether the vat number should be collected in that case. This filter provides the option to allow users to enter a VAT number even if their billing country is the same as the seller's country.