### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -154,7 +154,7 @@ function pmprovat_enqueue_scripts() {
 		return;
 
 	//only if we're on the checkout page
-	if(!empty($_REQUEST['level']) || is_page($pmpro_pages['checkout'])) {
+	if ( pmpro_is_checkout() ) {
 		//register
 		wp_register_script('pmprovat', plugin_dir_url( __FILE__ ) . 'js/pmprovat.js', array('jquery'), PMPRO_VAT_TAX_VERSION);
 


### PR DESCRIPTION
This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_is_checkout()` function.