### PR TITLE
Remove the validation tag on re-check passing a not-valid vat number

### DIFF
--- a/js/pmprovat.js
+++ b/js/pmprovat.js
@@ -102,6 +102,8 @@ jQuery(document).ready(function(){
 						jQuery('#pmpro_message, #vat_number_message').removeClass('pmpro_success');
 						jQuery('#pmpro_message, #vat_number_message').addClass('pmpro_error');
 						jQuery('#pmpro_message, #vat_number_message').html(pmprovat.not_verified_text);
+
+						jQuery('#pmpro_form #vat_number_verified').remove();
 					}
 				}
 			});


### PR DESCRIPTION
If the user changes the vat number after validation with an invalid one, the validation tag is not removed.
This PR address this issue by removing the validated tag, in case.