### PR TITLE
Never show errors when debug is NOT set. Write on the logs.

### DIFF
--- a/includes/vatValidation.class.php
+++ b/includes/vatValidation.class.php
@@ -3,7 +3,7 @@ class vatValidation
 {
 	const WSDL = "https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl";
 	private $_client = null;
-	private $options  = array(
+	private $_options  = array(
 						'debug' => false,
 						);	
 	
@@ -36,9 +36,8 @@ class vatValidation
 
 			$rs = $this->_client->checkVat( array('countryCode' => $countryCode, 'vatNumber' => $vatNumber) );
 
-				if($this->isDebug()) {
-			$this->trace('Web Service result', $this->_client->__getLastResponse());	
-		}
+			$this->trace('Web Service result', $this->_client->__getLastResponse());
+
 				if($rs->valid) {
 				$this->_valid = true;
 				list($denomination,$name) = explode(" " ,$rs->name,2);
@@ -79,7 +78,11 @@ class vatValidation
 		return ($this->_options['debug'] === true);
 	}
 	private function trace($title,$body) {
-		echo '<h2>TRACE: '.$title.'</h2><pre>'. htmlentities($body).'</pre>';
+		if ( $this->isDebug() ) {
+			echo '<h2>TRACE: '.$title.'</h2><pre>'. htmlentities($body).'</pre>';
+		} else {
+			error_log( 'TRACE: ' . $title . "\n" . $body . "\n" );
+		}
 	}
 	private function cleanUpString($string) {
         for($i=0;$i<100;$i++)

--- a/includes/vatValidation.class.php
+++ b/includes/vatValidation.class.php
@@ -28,6 +28,10 @@ class vatValidation
 		}
 	}
 	public function check($countryCode, $vatNumber) {
+		// ensure previous results are cleared
+		$this->_failed = false;
+		$this->_valid = false;
+		$this->_data = array();
 
 		try {
 			// Fix this issue for Greece.
@@ -49,14 +53,13 @@ class vatValidation
 									);
 				return true;
 			} else {
-				$this->_valid = false;
-				$this->_data = array();
 				return false;
 			}
 
 		} catch(Exception $e) {
 			$this->trace( 'Web Service exception', $e->getMessage() );
 			$this->_failed = true;
+			return false;
 		}	
 	}
 

--- a/includes/vatValidation.class.php
+++ b/includes/vatValidation.class.php
@@ -83,8 +83,8 @@ class vatValidation
 		return $this->_data['address'];
 	}
 	
-	public function isDebug() {		
-		return ($this->_options['debug'] === true);
+	public function isDebug() {
+		return false !== $this->_options['debug'];
 	}
 	private function trace($title,$body) {
 		if ( $this->isDebug() ) {

--- a/includes/vatValidation.class.php
+++ b/includes/vatValidation.class.php
@@ -88,9 +88,13 @@ class vatValidation
 	}
 	private function trace($title,$body) {
 		if ( $this->isDebug() ) {
-			echo '<h2>TRACE: '.$title.'</h2><pre>'. htmlentities($body).'</pre>';
-		} else {
-			error_log( 'TRACE: ' . $title . "\n" . $body . "\n" );
+			if ( $this->isDebug() ) {
+				if ( 'log' === $this->_options['debug'] ) {
+					error_log( 'TRACE: ' . $title . "\n" . $body . "\n" );
+				} else {
+					echo '<h2>TRACE: ' . $title . '</h2><pre>' . htmlentities( $body ) . '</pre>';
+				}
+			}
 		}
 	}
 	private function cleanUpString($string) {

--- a/includes/vatValidation.class.php
+++ b/includes/vatValidation.class.php
@@ -5,8 +5,9 @@ class vatValidation
 	private $_client = null;
 	private $_options  = array(
 						'debug' => false,
-						);	
-	
+						);
+
+	private $_failed = false;
 	private $_valid = false;
 	private $_data = array();
 	
@@ -54,14 +55,19 @@ class vatValidation
 			}
 
 		} catch(Exception $e) {
-			// die quietly
+			$this->trace( 'Web Service exception', $e->getMessage() );
+			$this->_failed = true;
 		}	
 	}
 
 	public function isValid() {
 		return $this->_valid;
 	}
-	
+
+	public function isFailed() {
+		return $this->_failed;
+	}
+
 	public function getDenomination() {
 		return $this->_data['denomination'];
 	}


### PR DESCRIPTION
Fix: Working on the code I noticed that private $option should be $_options instead.

Enhance: **The class will never write publicly anymore, except when debugging.**
It should respect what's defined by debug options, to avoid weird messages to the website users.

Enhance: **Also tracing if web service request failed. And marking as _failed for further detection.**
Useful for developers who don't want to set that VAT number as invalid, if the request failed/timeout/etc.

Enhance: **Ensure previous results are cleared when looking up more than one vat number.**