### PR TITLE
Strip out country code when entered.

### DIFF
--- a/includes/vatValidation.class.php
+++ b/includes/vatValidation.class.php
@@ -34,6 +34,9 @@ class vatValidation
 				$countryCode = 'EL';
 			}
 
+			// Strip the country code from the vat number
+			$vatNumber = preg_replace('/^'.$countryCode.'/','',$vatNumber);
+			
 			$rs = $this->_client->checkVat( array('countryCode' => $countryCode, 'vatNumber' => $vatNumber) );
 
 				if($this->isDebug()) {
@@ -97,7 +100,7 @@ class vatValidation
         foreach($words as $k=>$w)
         {                       
            	$newString .= ucfirst(strtolower($w))." "; 
-        }                
+        }
         return $newString;
 	}
 }

--- a/includes/vatValidation.class.php
+++ b/includes/vatValidation.class.php
@@ -35,7 +35,7 @@ class vatValidation
 			}
 
 			// Strip the country code from the vat number
-			$vatNumber = preg_replace('/^'.$countryCode.'/','',$vatNumber);
+			$vatNumber = preg_replace( '/^' . $countryCode . '/', '', $vatNumber) ;
 			
 			$rs = $this->_client->checkVat( array('countryCode' => $countryCode, 'vatNumber' => $vatNumber) );
 

--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -683,6 +683,9 @@ function pmprovat_pmpro_added_order($order)
 	if($vat_rate === 0) $vat_rate = '';		//we want this blank if 0
 	
 	$notes = "";
+	
+	// Strip the country code from the VAT number if it's there. We don't need it.
+	$vat_number = preg_replace('/^' . $eucountry . '/', '', $vat_number);
 
 	if(!empty($vat_number) || !empty($eucountry)) {
 		$notes .= "\n---\n";

--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -685,7 +685,7 @@ function pmprovat_pmpro_added_order($order)
 	$notes = "";
 	
 	// Strip the country code from the VAT number if it's there. We don't need it.
-	$vat_number = preg_replace('/^' . $eucountry . '/', '', $vat_number);
+	$vat_number = preg_replace( '/^' . $eucountry . '/', '', $vat_number );
 
 	if(!empty($vat_number) || !empty($eucountry)) {
 		$notes .= "\n---\n";


### PR DESCRIPTION
* Strips out country code from the VAT number for validation, to help improve UX.

This will still validate the VAT number if the country code is left out or included.

Resolves: https://github.com/strangerstudios/pmpro-vat-tax/issues/59
