### PR TITLE
Fix "Seller Country" setting not showing in PMPro v3.5+

### DIFF
--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -553,6 +553,9 @@ function pmprovat_plugin_row_meta($links, $file) {
 }
 add_filter('plugin_row_meta', 'pmprovat_plugin_row_meta', 10, 2);
 
+/**
+ * Legacy function for before PMPro v3.5.
+ */
 function pmprovat_pmpro_payment_option_fields($payment_option_values, $gateway)
 {
 
@@ -595,6 +598,53 @@ function pmprovat_pmpro_payment_option_fields($payment_option_values, $gateway)
 
 }
 add_action('pmpro_payment_option_fields', 'pmprovat_pmpro_payment_option_fields', 10, 2);
+
+/**
+ * Add "seller country" setting to PMPro Settings > Payment settings page.
+ *
+ * Runs for PMPro v3.5 and later.
+ */
+function pmprovat_pmpro_after_payment_settings() {
+	global $pmpro_european_union;
+
+	if ( isset( $_REQUEST['pmprovt_seller_country'] ) ) {
+		$seller_country = sanitize_text_field( wp_unslash( $_REQUEST['pmprovt_seller_country'] ) );
+		update_option( 'pmprovt_seller_country', $seller_country, 'no' );
+	} else {
+		$seller_country = get_option( 'pmprovt_seller_country' );
+	}
+	?>
+	<table class="form-table">
+		<tbody>
+			<tr class="pmpro_settings_divider">
+				<td colspan="2">
+					<?php _e('EU VAT Seller Country', 'pmpro-vat-tax' ); ?>
+				</td>
+			</tr>
+			
+			<tr>
+				<th scope="row" valign="top">
+					<label for="pmprovt_seller_country"><?php _e('Seller Country', 'pmpro-vat-tax' );?>:</label>
+				</th>
+				<td>
+					<select id = "pmprovt_seller_country" name = "pmprovt_seller_country">
+						<?php
+							foreach($pmpro_european_union as $abbr => $country)
+							{
+
+							?>
+							<option value="<?php echo $abbr?>" <?php if($abbr == $seller_country) { ?>selected="selected"<?php } ?>><?php echo $country?></option>
+							<?php
+							}
+						?>
+					</select>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<?php
+}
+add_action( 'pmpro_after_payment_settings', 'pmprovat_pmpro_after_payment_settings' );
 
 /**
  * Function to add VAT Number to order notes

--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -618,13 +618,13 @@ function pmprovat_pmpro_after_payment_settings() {
 		<tbody>
 			<tr class="pmpro_settings_divider">
 				<td colspan="2">
-					<?php _e('EU VAT Seller Country', 'pmpro-vat-tax' ); ?>
+					<?php esc_html_e('EU VAT Seller Country', 'pmpro-vat-tax' ); ?>
 				</td>
 			</tr>
 			
 			<tr>
 				<th scope="row" valign="top">
-					<label for="pmprovt_seller_country"><?php _e('Seller Country', 'pmpro-vat-tax' );?>:</label>
+					<label for="pmprovt_seller_country"><?php esc_html_e('Seller Country', 'pmpro-vat-tax' );?>:</label>
 				</th>
 				<td>
 					<select id = "pmprovt_seller_country" name = "pmprovt_seller_country">
@@ -633,7 +633,7 @@ function pmprovat_pmpro_after_payment_settings() {
 							{
 
 							?>
-							<option value="<?php echo $abbr?>" <?php if($abbr == $seller_country) { ?>selected="selected"<?php } ?>><?php echo $country?></option>
+							<option value="<?php echo esc_attr( $abbr )?>" <?php if($abbr == $seller_country) { ?>selected="selected"<?php } ?>><?php echo esc_html($country)?></option>
 							<?php
 							}
 						?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The PMPro Payment settings page was updated in 3.5 causing the "Seller Country" setting to no longer be shown or editable on the Payment settings page. This PR fixes that issue by using a new 3.5 filter to add the setting.

I also noticed that this setting was hardly used in the plugin logic and am curious if it is still necessary, especially since it has been missing for around 3 months at this point with the issue not being reported. Perhaps this is instead a chance to simplify the plugin by removing this setting.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.