### PR TITLE
Use original subscription order to determine VAT source in pmpro_added_order

### DIFF
--- a/pmpro-vat-tax.php
+++ b/pmpro-vat-tax.php
@@ -652,23 +652,28 @@ add_action( 'pmpro_after_payment_settings', 'pmprovat_pmpro_after_payment_settin
 function pmprovat_pmpro_added_order($order)
 {
 	global $wpdb, $pmpro_european_union;
-	
-	if( function_exists( 'pmpro_doing_webhook' ) && pmpro_doing_webhook() ){
 
+	// Assume this is the first order unless we find an earlier order in this subscription.
+	$is_first_subscription_order = true;
+	$first_order = false;
+
+	// Get the first order in this subscription chain.
+	if ( method_exists( $order, 'get_original_subscription_order' ) && ! empty( $order->subscription_transaction_id ) ) {
 		$first_order = $order->get_original_subscription_order( $order->subscription_transaction_id );
+	}
 
-		if( !empty( $first_order ) ){
+	if ( ! empty( $first_order ) && ! empty( $first_order->id ) && ! empty( $order->id ) ) {
+		$is_first_subscription_order = ( (int) $first_order->id === (int) $order->id );
+	}
 
-			$vat_number = pmprovat_get_tax_order_notes( 'EU_VAT_NUMBER', $first_order );
-			$eucountry = pmprovat_get_tax_order_notes( 'EU_VAT_COUNTRY', $first_order );
-			$vat_rate = floatval( pmprovat_get_tax_order_notes( 'EU_VAT_TAX_RATE', $first_order ) );
+	if ( ! $is_first_subscription_order ) {
+		$vat_number = pmprovat_get_tax_order_notes( 'EU_VAT_NUMBER', $first_order );
+		$eucountry = pmprovat_get_tax_order_notes( 'EU_VAT_COUNTRY', $first_order );
+		$vat_rate = floatval( pmprovat_get_tax_order_notes( 'EU_VAT_TAX_RATE', $first_order ) );
 
-			$order->subtotal = pmprovat_calculate_subtotal( $order->total, $vat_rate );
+		$order->subtotal = pmprovat_calculate_subtotal( $order->total, $vat_rate );
+		$order->tax = $order->total - $order->subtotal;
 
-			$order->tax = $order->total - $order->subtotal;
-
-		}
-	
 		$wpdb->update(
 			$wpdb->pmpro_membership_orders,
 			array( 'tax' => $order->tax, 'subtotal' => $order->subtotal ),
@@ -676,7 +681,6 @@ function pmprovat_pmpro_added_order($order)
 			array( '%s', '%s' ),
 			array( '%d' )
 		);
-
 	} else {
 
 		if(!empty($_REQUEST['vat_number']))


### PR DESCRIPTION
## Context
This change updates how `pmprovat_pmpro_added_order()` decides where VAT data should come from when an order is saved.

Historically, the add-on used webhook request context (`pmpro_doing_webhook()`) as the switch:
- If webhook: treat the order like a recurring follow-up order and copy VAT data from the original subscription order.
- If not webhook: treat the order like an initial checkout order and use request/session VAT values.

## Issue We Were Facing
That webhook-vs-non-webhook distinction is no longer reliable for identifying order type.

In current PMPro flows:
- async/offsite completion can finalize an **initial** checkout on a later request,
- and webhook execution context is not a dependable proxy for whether an order is initial vs recurring.

Result: the VAT add-on can make the wrong decision about VAT source because it is keying off request context rather than subscription order position.

## Why This Change Is Needed
The VAT decision should be based on the data model (where this order sits in the subscription chain), not transport/runtime context (whether the current request is a webhook).

The real business rule is:
- **Recurring follow-up order**: copy VAT metadata from the original subscription order and back-calculate subtotal/tax.
- **Initial order**: use checkout request/session VAT inputs.

## Approach Implemented
In `pmprovat_pmpro_added_order()`:
1. Stop using `pmpro_doing_webhook()` for branching.
2. Use `get_original_subscription_order( $order->subscription_transaction_id )` to identify the first order in the subscription chain.
3. Compare first order ID with current order ID.
4. Branch by order position:
   - Not first order: copy `EU_VAT_*` note fields from first order and reverse-calculate subtotal/tax.
   - First order (or no subscription context): keep existing request/session VAT logic.

## Why We Chose This Approach
- It directly maps to the actual domain rule (initial vs recurring) instead of incidental request state.
- It is minimal and low-risk: no schema changes, no core API changes, no broader gateway flow changes.
- It reuses an existing method already used in this add-on (`get_original_subscription_order`), which keeps compatibility straightforward.
- It reduces coupling to `pmpro_doing_webhook()` read behavior, which is being reconsidered/deprecated.

## Behavior and Compatibility Notes
- Recurring subscription orders continue to inherit VAT metadata from the original subscription order.
- First subscription orders continue to use request/session VAT inputs.
- If no original subscription order is found, logic naturally falls back to first-order/request behavior (safer default than webhook-context assumptions).

## Risk Assessment
Risk is low and localized to one add-on function.

Primary risk surface:
- edge cases where subscription transaction IDs are missing or inconsistent.

Mitigation:
- fallback behavior remains the existing request/session VAT path.
- no changes to data storage format (`EU_VAT_*` notes remain unchanged).

## Testing
- `php -l pmpro-vat-tax.php` (passes)
- Code-path verification:
  - Initial checkout path still executes request/session VAT logic.
  - Non-initial subscription orders still copy VAT from the original order and recalculate subtotal/tax.
